### PR TITLE
Support OS configured proxies

### DIFF
--- a/lbcapi/api.py
+++ b/lbcapi/api.py
@@ -114,6 +114,7 @@ class Connection():
 
                 # Send request
                 session = requests.Session()
+                session.proxies=urllib.request.getproxies()
                 response = session.send(api_request, stream=stream)
 
                 # If HMAC Nonce is already used, then wait a little and try again

--- a/lbcapi/api.py
+++ b/lbcapi/api.py
@@ -4,6 +4,7 @@ import hmac as hmac_lib
 import requests
 import sys
 import time
+from urllib import request
 try:
     # Python 3.x
     from urllib.parse import urlparse
@@ -114,7 +115,7 @@ class Connection():
 
                 # Send request
                 session = requests.Session()
-                session.proxies=urllib.request.getproxies()
+                session.proxies=request.getproxies()
                 response = session.send(api_request, stream=stream)
 
                 # If HMAC Nonce is already used, then wait a little and try again


### PR DESCRIPTION
Operating system defined proxies using http_proxy or https_proxy (such as a local Shadowsocks or a corporate proxy server) will be automatically detected and used when making api requests